### PR TITLE
feat: update rush-cli version and add Kubernetes manifest validation

### DIFF
--- a/rush/Cargo.lock
+++ b/rush/Cargo.lock
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "rush-cli"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rush/Cargo.toml
+++ b/rush/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rush-cli"
-version = "0.0.20"
+version = "0.0.21"
 edition = "2021"
 authors = ["Troels F. Rønnow <wonop@wonop.com>"]
 description = "Rush Deployment: A tool to bring the development experience as close to the production experience as possible."

--- a/rush/src/builder/config.rs
+++ b/rush/src/builder/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     root_path: String,
     vault_name: String,
     k8s_encoder: String,
+    k8s_validator: String,
+    k8s_version: String,
     one_password_account: Option<String>,
     json_vault_dir: Option<String>,
     start_port: u16,
@@ -37,6 +39,12 @@ impl Config {
     }
     pub fn k8s_encoder(&self) -> &str {
         &self.k8s_encoder
+    }
+    pub fn k8s_validator(&self) -> &str {
+        &self.k8s_validator
+    }
+    pub fn k8s_version(&self) -> &str {
+        &self.k8s_version
     }
 
     pub fn vault_name(&self) -> &str {
@@ -152,6 +160,30 @@ impl Config {
             _ => panic!("Invalid environment"),
         };
 
+        let k8s_validator = match environment.as_str() {
+            "dev" => std::env::var("K8S_VALIDATOR_DEV")
+                .expect("K8S_VALIDATOR_DEV environment variable not found"),
+            "prod" => std::env::var("K8S_VALIDATOR_PROD")
+                .expect("K8S_VALIDATOR_PROD environment variable not found"),
+            "staging" => std::env::var("K8S_VALIDATOR_STAGING")
+                .expect("K8S_VALIDATOR_STAGING environment variable not found"),
+            "local" => std::env::var("K8S_VALIDATOR_LOCAL")
+                .expect("K8S_VALIDATOR_LOCAL environment variable not found"),
+            _ => panic!("Invalid environment"),
+        };
+
+        let k8s_version = match environment.as_str() {
+            "dev" => std::env::var("K8S_VERSION_DEV")
+                .expect("K8S_VERSION_DEV environment variable not found"),
+            "prod" => std::env::var("K8S_VERSION_PROD")
+                .expect("K8S_VERSION_PROD environment variable not found"),
+            "staging" => std::env::var("K8S_VERSION_STAGING")
+                .expect("K8S_VERSION_STAGING environment variable not found"),
+            "local" => std::env::var("K8S_VERSION_LOCAL")
+                .expect("K8S_VERSION_LOCAL environment variable not found"),
+            _ => panic!("Invalid environment"),
+        };
+
         let domain_template =
             match environment.as_str() {
                 "dev" => {
@@ -237,6 +269,8 @@ impl Config {
             docker_registry,
             vault_name,
             k8s_encoder,
+            k8s_validator,
+            k8s_version,
             one_password_account,
             json_vault_dir,
             start_port,

--- a/rush/src/cluster/mod.rs
+++ b/rush/src/cluster/mod.rs
@@ -1,6 +1,7 @@
 mod infrastructure;
 mod k8_encoder;
 mod k8s;
+mod validation;
 
 use crate::toolchain::ToolchainContext;
 use crate::utils::run_command;
@@ -11,6 +12,7 @@ use std::sync::Arc;
 pub use infrastructure::InfrastructureRepo;
 pub use k8_encoder::{K8Encoder, NoopEncoder, SealedSecretsEncoder};
 pub use k8s::K8ClusterManifests;
+pub use validation::{K8Validation, KubeconformValidator, KubevalValidator};
 
 pub struct Minikube {
     toolchain: Arc<ToolchainContext>,

--- a/rush/src/cluster/validation.rs
+++ b/rush/src/cluster/validation.rs
@@ -1,0 +1,57 @@
+use std::process::Command;
+
+pub trait K8Validation {
+    fn validate(&self, path: &str, version: &str) -> Result<(), String>;
+}
+
+pub struct KubeconformValidator;
+
+impl K8Validation for KubeconformValidator {
+    fn validate(&self, path: &str, version: &str) -> Result<(), String> {
+        println!(
+            "Executing: kubeconform -kubernetes-version {} -strict {}",
+            version, path
+        );
+        let output = Command::new("kubeconform")
+            .arg("-kubernetes-version")
+            .arg(version)
+            .arg("-strict")
+            .arg(path)
+            .output()
+            .map_err(|e| format!("Failed to execute kubeconform: {}", e))?;
+
+        if !output.status.success() {
+            Err(format!(
+                "kubeconform validation failed:\nstderr:\n{}\nstdout:\n{}",
+                String::from_utf8_lossy(&output.stderr),
+                String::from_utf8_lossy(&output.stdout)
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub struct KubevalValidator;
+
+impl K8Validation for KubevalValidator {
+    fn validate(&self, path: &str, version: &str) -> Result<(), String> {
+        let output = Command::new("kubeval")
+            .arg("--strict")
+            .arg("--kubernetes-version")
+            .arg(version)
+            .arg(path)
+            .output()
+            .map_err(|e| format!("Failed to execute kubeval: {}", e))?;
+
+        if !output.status.success() {
+            Err(format!(
+                "kubeval validation failed:\nstderr:\n{}\nstdout:\n{}",
+                String::from_utf8_lossy(&output.stderr),
+                String::from_utf8_lossy(&output.stdout)
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/rush/src/toolchain/mod.rs
+++ b/rush/src/toolchain/mod.rs
@@ -20,6 +20,8 @@ pub struct ToolchainContext {
     kubectl: Option<String>,
     kubectx: Option<String>,
     minikube: Option<String>,
+    kubeconform: Option<String>,
+    kubeval: Option<String>,
 
     // Secondary
     cc: String,
@@ -51,6 +53,8 @@ impl ToolchainContext {
             kubectl: first_which(vec!["kubectl"]),
             kubectx: first_which(vec!["kubectx"]),
             minikube: first_which(vec!["minikube"]),
+            kubeconform: first_which(vec!["kubeconform"]),
+            kubeval: first_which(vec!["kubeval"]),
 
             cc: first_which(vec!["clang", "gcc"])
                 .expect("None of the default toolchains are availablefor this architecture"),
@@ -122,6 +126,8 @@ impl ToolchainContext {
                 kubectl: first_which(vec!["kubectl"]),
                 kubectx: first_which(vec!["kubectx"]),
                 minikube: first_which(vec!["minikube"]),
+                kubeconform: first_which(vec!["kubeconform"]),
+                kubeval: first_which(vec!["kubeval"]),
 
                 cc,
                 cxx,
@@ -222,6 +228,22 @@ impl ToolchainContext {
 
     pub fn kubectx(&self) -> &str {
         self.kubectx.as_ref().expect("kubectx not found")
+    }
+
+    pub fn has_kubeconform(&self) -> bool {
+        self.kubeconform.is_some()
+    }
+
+    pub fn kubeconform(&self) -> &str {
+        self.kubeconform.as_ref().expect("kubeconform not found")
+    }
+
+    pub fn has_kubeval(&self) -> bool {
+        self.kubeval.is_some()
+    }
+
+    pub fn kubeval(&self) -> &str {
+        self.kubeval.as_ref().expect("kubeval not found")
     }
 
     pub fn git(&self) -> &str {


### PR DESCRIPTION
- Increment rush-cli version from 0.0.20 to 0.0.21.
- Introduce Kubernetes manifest validation functionality.
- Add K8S_VALIDATOR and K8S_VERSION environment variables for multiple environments (dev, prod, staging, local).
- Implement validation traits and structs for kubeconform and kubeval.
- Enhance the main command interface to include a subcommand for validating Kubernetes manifests.

This commit sets the foundation for robust validation of Kubernetes manifests during deployment processes.